### PR TITLE
Update CSP for CDN script

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ app.use((req, res, next) => {
   if (process.env.NODE_ENV === 'production') {
     res.header('Content-Security-Policy', 
       "default-src 'self'; " +
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.gpteng.co; " +
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
       "font-src 'self' https://fonts.gstatic.com; " +
       "img-src 'self' data: https:; " +


### PR DESCRIPTION
## Summary
- allow `https://cdn.gpteng.co` in CSP `script-src` directive

## Testing
- `npm test` *(fails: No test files found)*
- `npm run test:server` *(fails: dist directory does not exist)*
- `NODE_ENV=production node server.js` and `curl -I http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_e_688a441987f0832faae3027edcee693a