### PR TITLE
Unify OpenAI API key storage

### DIFF
--- a/src/components/ApiKeyModal.tsx
+++ b/src/components/ApiKeyModal.tsx
@@ -21,9 +21,15 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ open, onOpenChange }) => {
 
   useEffect(() => {
     if (open) {
-      // Load existing API key from localStorage
-      const savedKey = localStorage.getItem('openai_api_key') || '';
+      // Load existing API key from localStorage (support legacy key)
+      const newKey = localStorage.getItem('openai_api_key');
+      const oldKey = localStorage.getItem('openai-api-key');
+      const savedKey = newKey || oldKey || '';
       setApiKey(savedKey);
+      if (oldKey && !newKey) {
+        localStorage.setItem('openai_api_key', oldKey);
+        localStorage.removeItem('openai-api-key');
+      }
       setIsValid(null);
     }
   }, [open]);
@@ -66,6 +72,7 @@ const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ open, onOpenChange }) => {
   const handleSave = () => {
     if (apiKey.trim()) {
       localStorage.setItem('openai_api_key', apiKey.trim());
+      localStorage.removeItem('openai-api-key');
       toast({
         title: "API Key Saved",
         description: "Your OpenAI API key has been saved locally.",

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -29,7 +29,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ onCodeGenerated }) => {
   const getProviderStatus = () => {
     return {
       gemini: !!localStorage.getItem('gemini_api_key'),
-      openai: !!localStorage.getItem('openai_api_key'),
+      openai: !!(localStorage.getItem('openai_api_key') || localStorage.getItem('openai-api-key')),
       claude: !!localStorage.getItem('claude_api_key')
     };
   };
@@ -67,8 +67,15 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ onCodeGenerated }) => {
     setIsLoading(true);
 
     try {
-      // Get API key from localStorage
-      const apiKey = localStorage.getItem(`${selectedProvider}_api_key`);
+      // Get API key from localStorage (support legacy OpenAI key)
+      let apiKey = localStorage.getItem(`${selectedProvider}_api_key`);
+      if (!apiKey && selectedProvider === 'openai') {
+        apiKey = localStorage.getItem('openai-api-key');
+        if (apiKey) {
+          localStorage.setItem('openai_api_key', apiKey);
+          localStorage.removeItem('openai-api-key');
+        }
+      }
       
       if (!apiKey) {
         throw new Error(`Please configure your ${selectedProvider.toUpperCase()} API key in settings`);

--- a/src/components/PromptWorkspace.tsx
+++ b/src/components/PromptWorkspace.tsx
@@ -71,11 +71,19 @@ const PromptWorkspace: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [filteredSessions, setFilteredSessions] = useState<PromptSession[]>([]);
   
-  // Load API key from localStorage
+  // Load API key from localStorage (migrate from old key if present)
   useEffect(() => {
-    const storedApiKey = localStorage.getItem('openai-api-key');
+    const newKey = localStorage.getItem('openai_api_key');
+    const oldKey = localStorage.getItem('openai-api-key');
+    const storedApiKey = newKey || oldKey;
+
     if (storedApiKey) {
       setApiKey(storedApiKey);
+      // migrate to new key if needed
+      if (oldKey && !newKey) {
+        localStorage.setItem('openai_api_key', oldKey);
+        localStorage.removeItem('openai-api-key');
+      }
     }
   }, []);
   
@@ -273,7 +281,8 @@ const someVar = someCondition
   
   // Handle saving API key
   const handleSaveApiKey = () => {
-    localStorage.setItem('openai-api-key', apiKey);
+    localStorage.setItem('openai_api_key', apiKey);
+    localStorage.removeItem('openai-api-key');
     addSystemLog('Saved API key');
 // Handle clearing output history
   const handleClearOutputHistory = () => {
@@ -298,7 +307,8 @@ const someVar = someCondition
   
   // Handle saving API key
   const handleSaveApiKey = () => {
-    localStorage.setItem('openai-api-key', apiKey);
+    localStorage.setItem('openai_api_key', apiKey);
+    localStorage.removeItem('openai-api-key');
   
   // Format date for display
   const formatDate = (timestamp: number): string => {

--- a/src/components/PromptWorkspace.tsx
+++ b/src/components/PromptWorkspace.tsx
@@ -309,7 +309,9 @@ const someVar = someCondition
   const handleSaveApiKey = () => {
     localStorage.setItem('openai_api_key', apiKey);
     localStorage.removeItem('openai-api-key');
-  
+    addSystemLog('Saved API key');
+  };
+
   // Format date for display
   const formatDate = (timestamp: number): string => {
     return new Date(timestamp).toLocaleString();


### PR DESCRIPTION
### **User description**
## Summary
- replace `openai-api-key` references with `openai_api_key`
- migrate existing keys on load in PromptWorkspace and ApiKeyModal
- allow ChatInterface to read old key format

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688a44e5bc98832fb48bcca8b6006176


___

### **PR Type**
Enhancement


___

### **Description**
- Standardize OpenAI API key storage format from `openai-api-key` to `openai_api_key`

- Add automatic migration from legacy key format

- Maintain backward compatibility for existing users

- Update key handling across all components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy Key: openai-api-key"] --> B["Migration Logic"]
  B --> C["New Key: openai_api_key"]
  B --> D["Remove Legacy Key"]
  C --> E["Updated Components"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApiKeyModal.tsx</strong><dd><code>Add API key migration in modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ApiKeyModal.tsx

<ul><li>Add migration logic to check for legacy <code>openai-api-key</code> format<br> <li> Automatically migrate to new <code>openai_api_key</code> format on modal open<br> <li> Remove legacy key after successful migration<br> <li> Clean up legacy key on save operation</ul>


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/cyber-prompt-builder/pull/12/files#diff-6bf9d6ce69151fc005a129c524564239665e912404b88f65548ca617cb144882">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatInterface.tsx</strong><dd><code>Support legacy key format in chat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ChatInterface.tsx

<ul><li>Update provider status check to support both key formats<br> <li> Add fallback to legacy key format for OpenAI provider<br> <li> Migrate legacy key to new format when found<br> <li> Maintain backward compatibility during transition</ul>


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/cyber-prompt-builder/pull/12/files#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PromptWorkspace.tsx</strong><dd><code>Migrate API key format in workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/PromptWorkspace.tsx

<ul><li>Update API key loading to check both formats<br> <li> Add migration from legacy to new key format<br> <li> Update save operation to use new format<br> <li> Remove legacy key after migration</ul>


</details>


  </td>
  <td><a href="https://github.com/numbpill3d/cyber-prompt-builder/pull/12/files#diff-a2135eff7f8ac375a83dcc919617b18a60bab5f6e569cea3e1fa4260cc931ae7">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Standardize OpenAI API key storage by consolidating localStorage references to a single key format and migrate any legacy entries to the new format across all relevant components

New Features:
- Automatically detect and migrate legacy `openai-api-key` entries to `openai_api_key` on load in PromptWorkspace, ApiKeyModal, and ChatInterface

Enhancements:
- Replace all uses of the hyphenated key with the underscore format in save and load operations
- Support backward compatibility by falling back to the legacy key when reading OpenAI credentials before migration
- Remove legacy key entries from localStorage after successful migration