### PR TITLE
Add basic panel components

### DIFF
--- a/src/components/AnalysisPanel.tsx
+++ b/src/components/AnalysisPanel.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Card } from './ui/card';
+
+interface TokenEstimation {
+  count: number;
+  model: string;
+  costEstimate?: number;
+}
+
+export interface AnalysisData {
+  tokenEstimation: TokenEstimation;
+  confidenceScore: number;
+  complexity: string;
+  suggestedImprovements: string[];
+  promptType: string[];
+}
+
+interface AnalysisPanelProps {
+  analysis: AnalysisData | null;
+}
+
+const AnalysisPanel: React.FC<AnalysisPanelProps> = ({ analysis }) => {
+  if (!analysis) {
+    return <div className="text-gray-400">No analysis available</div>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <Card className="p-2 bg-black/30 border-purple-500/10">
+        <p className="text-sm text-gray-300">
+          Tokens: {analysis.tokenEstimation.count}
+        </p>
+      </Card>
+    </div>
+  );
+};
+
+export default AnalysisPanel;

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Textarea } from './ui/textarea';
+import { Button } from './ui/button';
+
+interface EditorPanelProps {
+  prompt: string;
+  sessionId?: string;
+  onChangePrompt: (value: string) => void;
+  onSavePrompt?: (sessionId: string, prompt: string) => void;
+  onExecutePrompt?: (prompt: string) => void;
+}
+
+const EditorPanel: React.FC<EditorPanelProps> = ({
+  prompt,
+  sessionId,
+  onChangePrompt,
+  onSavePrompt,
+  onExecutePrompt
+}) => {
+  return (
+    <div className="flex flex-col space-y-2 h-full">
+      <Textarea
+        value={prompt}
+        onChange={(e) => onChangePrompt(e.target.value)}
+        className="flex-1 bg-black/30"
+      />
+      <div className="flex justify-end space-x-2">
+        {onSavePrompt && sessionId && (
+          <Button size="sm" onClick={() => onSavePrompt(sessionId, prompt)}>
+            Save
+          </Button>
+        )}
+        {onExecutePrompt && (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => onExecutePrompt(prompt)}
+          >
+            Run
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EditorPanel;

--- a/src/components/SessionPanel.tsx
+++ b/src/components/SessionPanel.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Card } from './ui/card';
+import { ScrollArea } from './ui/scroll-area';
+
+export interface BasicSession {
+  id: string;
+  name: string;
+}
+
+interface SessionPanelProps {
+  sessions: BasicSession[];
+  selectedSessionId?: string;
+  onSelectSession: (id: string) => void;
+}
+
+const SessionPanel: React.FC<SessionPanelProps> = ({
+  sessions,
+  selectedSessionId,
+  onSelectSession
+}) => {
+  return (
+    <ScrollArea className="space-y-2">
+      {sessions.map((session) => (
+        <Card
+          key={session.id}
+          onClick={() => onSelectSession(session.id)}
+          className={`p-2 cursor-pointer ${
+            selectedSessionId === session.id ? 'border-purple-500' : ''
+          }`}
+        >
+          {session.name}
+        </Card>
+      ))}
+    </ScrollArea>
+  );
+};
+
+export default SessionPanel;


### PR DESCRIPTION
## Summary
- add simple `SessionPanel`, `EditorPanel`, and `AnalysisPanel`
- wire minimal props for sessions, editor, and analysis display

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688b166c31dc832fb518b024bdccdadf