### PR TITLE
Implement environment-aware storage service

### DIFF
--- a/shared/services/storage.ts
+++ b/shared/services/storage.ts
@@ -1,0 +1,93 @@
+export interface StorageInterface {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  keys(): string[];
+}
+
+class BrowserStorage implements StorageInterface {
+  getItem(key: string): string | null {
+    return typeof localStorage === 'undefined' ? null : localStorage.getItem(key);
+  }
+  setItem(key: string, value: string): void {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(key, value);
+    }
+  }
+  removeItem(key: string): void {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(key);
+    }
+  }
+  keys(): string[] {
+    if (typeof localStorage === 'undefined') return [];
+    const result: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k) result.push(k);
+    }
+    return result;
+  }
+}
+
+import fs from 'fs';
+import path from 'path';
+
+class NodeStorage implements StorageInterface {
+  private data: Record<string, string> = {};
+  private file: string;
+
+  constructor(filePath: string = path.join(process.cwd(), 'storage.json')) {
+    this.file = filePath;
+    this.load();
+  }
+
+  private load() {
+    try {
+      if (fs.existsSync(this.file)) {
+        this.data = JSON.parse(fs.readFileSync(this.file, 'utf8'));
+      }
+    } catch {
+      this.data = {};
+    }
+  }
+
+  private save() {
+    try {
+      fs.writeFileSync(this.file, JSON.stringify(this.data, null, 2));
+    } catch {
+      // ignore write errors
+    }
+  }
+
+  getItem(key: string): string | null {
+    return this.data[key] ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data[key] = value;
+    this.save();
+  }
+
+  removeItem(key: string): void {
+    delete this.data[key];
+    this.save();
+  }
+
+  keys(): string[] {
+    return Object.keys(this.data);
+  }
+}
+
+let storage: StorageInterface | null = null;
+
+export function getStorage(): StorageInterface {
+  if (!storage) {
+    if (typeof window === 'undefined') {
+      storage = new NodeStorage();
+    } else {
+      storage = new BrowserStorage();
+    }
+  }
+  return storage;
+}


### PR DESCRIPTION
## Summary
- add a simple `StorageInterface` with browser and Node implementations
- use the storage service in `SessionManager` instead of `localStorage`
- persist memory exports and imports via storage

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688b1678a634832fba060db961657b46