### PR TITLE
Add node-fetch polyfill

### DIFF
--- a/backend/polyfills/node-fetch.js
+++ b/backend/polyfills/node-fetch.js
@@ -1,0 +1,7 @@
+if (typeof globalThis.fetch === 'undefined') {
+  const fetchModule = await import('node-fetch');
+  globalThis.fetch = fetchModule.default;
+  globalThis.Headers = fetchModule.Headers;
+  globalThis.Request = fetchModule.Request;
+  globalThis.Response = fetchModule.Response;
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dotenv": "^16.4.5",
     "embla-carousel-react": "^8.3.0",
     "express": "^4.18.2",
+    "node-fetch": "^3.3.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/server-fixed.js
+++ b/server-fixed.js
@@ -1,3 +1,4 @@
+import '../backend/polyfills/node-fetch.js';
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+import './backend/polyfills/node-fetch.js';
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/simple-server.js
+++ b/simple-server.js
@@ -1,3 +1,4 @@
+import './backend/polyfills/node-fetch.js';
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/simple-test.js
+++ b/simple-test.js
@@ -1,3 +1,4 @@
+import './backend/polyfills/node-fetch.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/test-express.js
+++ b/test-express.js
@@ -1,3 +1,4 @@
+import './backend/polyfills/node-fetch.js';
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/test-server.js
+++ b/test-server.js
@@ -1,3 +1,4 @@
+import './backend/polyfills/node-fetch.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
## Summary
- import polyfill to ensure `fetch` exists in Node
- add `node-fetch` dependency
- polyfill `fetch` for Node servers

## Testing
- `npm install --silent` *(fails: network access required)*
- `npm test --silent` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688b167b2f8c832fae4e2802e5ce59d3