### PR TITLE
Add vitest tests for hooks and panel components

### DIFF
--- a/src/components/AutomationPanel.test.tsx
+++ b/src/components/AutomationPanel.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import AutomationPanel from './AutomationPanel';
+
+describe('AutomationPanel', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<AutomationPanel prompt="hi" apiKey="key" />);
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/src/components/ui/resizable.test.tsx
+++ b/src/components/ui/resizable.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from './resizable';
+import React from 'react';
+
+describe('Resizable panel components', () => {
+  it('renders panel group with panels and handle', () => {
+    const { container } = render(
+      <ResizablePanelGroup>
+        <ResizablePanel>One</ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel>Two</ResizablePanel>
+      </ResizablePanelGroup>
+    );
+
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/src/hooks/use-mobile.test.ts
+++ b/src/hooks/use-mobile.test.ts
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react';
+import { useMobile, useIsMobile } from './use-mobile';
+
+describe('useMobile', () => {
+  it('should return false by default', () => {
+    const { result } = renderHook(() => useMobile());
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useIsMobile', () => {
+  it('should return false by default', () => {
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react';
+import { useToast, toast } from './use-toast';
+
+describe('useToast', () => {
+  it('provides a toast function and list', () => {
+    const { result } = renderHook(() => useToast());
+    expect(typeof result.current.toast).toBe('function');
+    expect(Array.isArray(result.current.toasts)).toBe(true);
+  });
+
+  it('calls console.log when toast is invoked', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.toast('hello');
+    });
+
+    expect(spy).toHaveBeenCalledWith('Toast:', 'hello');
+    spy.mockRestore();
+  });
+});
+
+describe('toast helper', () => {
+  it('logs to console', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    toast('hi');
+    expect(spy).toHaveBeenCalledWith('Toast:', 'hi');
+    spy.mockRestore();
+  });
+});

--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -9,7 +9,49 @@ describe('useToast', () => {
   });
 
   it('calls console.log when toast is invoked', () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+import { renderHook, act } from '@testing-library/react';
+import { useToast, toast } from './use-toast';
+
+// Helper function to mock console.log
+const mockConsoleLog = () => {
+  return vi.spyOn(console, 'log').mockImplementation(() => {});
+};
+
+describe('useToast', () => {
+  let spy;
+
+  beforeEach(() => {
+    spy = mockConsoleLog();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('provides a toast function and list', () => {
+    const { result } = renderHook(() => useToast());
+    expect(typeof result.current.toast).toBe('function');
+    expect(Array.isArray(result.current.toasts)).toBe(true);
+  });
+
+  it('calls console.log when toast is invoked', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.toast('hello');
+    });
+
+    expect(spy).toHaveBeenCalledWith('Toast:', 'hello');
+  });
+});
+
+describe('toast helper', () => {
+  it('logs to console', () => {
+    const spy = mockConsoleLog();
+    toast('hi');
+    expect(spy).toHaveBeenCalledWith('Toast:', 'hi');
+    spy.mockRestore();
+  });
     const { result } = renderHook(() => useToast());
 
     act(() => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- add missing vitest setup file
- test `use-mobile` and `use-toast` hooks
- test `AutomationPanel` and resizable panel UI components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b1685e49c832fb92c24e8cebcd547

## Summary by Sourcery

Add vitest setup file and introduce unit tests for mobile and toast hooks as well as panel UI components

Tests:
- Add vitest setup file for initializing tests
- Add unit tests for use-mobile hook
- Add unit tests for use-toast hook
- Add tests for AutomationPanel component
- Add tests for resizable panel UI component