### PR TITLE
Fix duplicate handlers in PromptWorkspace

### DIFF
--- a/src/components/PromptWorkspace.tsx
+++ b/src/components/PromptWorkspace.tsx
@@ -153,17 +153,6 @@ const PromptWorkspace: React.FC = () => {
     addSystemLog(`Execution completed: ${result.error ? 'Error' : 'Success'}`);
     
     // Analyze the prompt
-const promptAnalysis = promptAnalyzer.analyzePrompt(currentPrompt);
-const someVar = someCondition
-  ? { model: 'gpt-4' }
-  : undefined;
-
-    };
-    
-    setOutputHistory(prev => [...prev, outputItem]);
-    addSystemLog(`Execution completed: ${result.error ? 'Error' : 'Success'}`);
-    
-    // Analyze the prompt
     try {
       const promptAnalysis = promptAnalyzer.analyzePrompt(currentPrompt);
       setAnalysis(promptAnalysis);
@@ -175,32 +164,6 @@ const someVar = someCondition
     setIsProcessing(false);
   };
   
-  // Handle session selection
-  const handleSelectSession = (sessionId: string) => {
-    setSelectedSessionId(sessionId);
-    
-    const session = promptMemoryStore.getSession(sessionId);
-    if (session && session.currentSnapshotId) {
-      const currentSnapshot = session.snapshots.find(s => s.id === session.currentSnapshotId);
-      if (currentSnapshot) {
-        setCurrentPrompt(currentSnapshot.content);
-        
-        // Analyze the prompt
-        try {
-          const promptAnalysis = promptAnalyzer.analyzePrompt(currentSnapshot.content);
-          setAnalysis(promptAnalysis);
-        } catch (error) {
-          console.error('Error analyzing prompt:', error);
-          addSystemLog(`Error analyzing prompt: ${error.message}`);
-        }
-        
-        addSystemLog(`Loaded session: ${session.name}`);
-      }
-    
-    setIsProcessing(false);
-  };
-  
-  // Handle session selection
   const handleSelectSession = (sessionId: string) => {
     setSelectedSessionId(sessionId);
     
@@ -272,28 +235,6 @@ const someVar = someCondition
     }
   };
   
-  // Handle clearing output history
-  const handleClearOutputHistory = () => {
-    setOutputHistory([]);
-    addSystemLog('Cleared output history');
-  };
-  
-  // Handle copying an output item
-  const handleCopyOutput = (item: OutputItem) => {
-    addSystemLog(`Copied output: ${item.id}`);
-  };
-  
-  // Handle removing an output item
-  const handleRemoveOutput = (id: string) => {
-    setOutputHistory(prev => prev.filter(item => item.id !== id));
-    addSystemLog(`Removed output: ${id}`);
-  };
-  
-  // Handle saving API key
-  const handleSaveApiKey = () => {
-    localStorage.setItem('openai_api_key', apiKey);
-    localStorage.removeItem('openai-api-key');
-    addSystemLog('Saved API key');
 // Handle clearing output history
   const handleClearOutputHistory = () => {
     setOutputHistory([]);


### PR DESCRIPTION
## Summary
- remove stray lines and duplicate handler definitions
- keep single implementation of output history handlers

## Testing
- `npm test` *(fails: No test files found)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688b169451a4832f8e942c682a3db9de