### PR TITLE
Add live clock to layout

### DIFF
--- a/frontend/components/CyberLayout.tsx
+++ b/frontend/components/CyberLayout.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Card } from './ui/card';
@@ -18,6 +18,16 @@ interface CyberLayoutProps {
 
 const CyberLayout: React.FC<CyberLayoutProps> = ({ children }) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [currentTime, setCurrentTime] = useState('');
+
+  useEffect(() => {
+    const updateTime = () => {
+      setCurrentTime(new Date().toLocaleTimeString());
+    };
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <div className="h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 text-white">
@@ -90,6 +100,7 @@ const CyberLayout: React.FC<CyberLayoutProps> = ({ children }) => {
               <div className="flex items-center space-x-4">
                 <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
                 <span className="text-sm text-gray-400">Online</span>
+                <span className="text-sm text-gray-400">{currentTime}</span>
               </div>
             </div>
           </header>


### PR DESCRIPTION
## Summary
- show the current time in `CyberLayout`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b169d5ee0832fba138f656bfb35d2